### PR TITLE
修复demo19定时器错误

### DIFF
--- a/demos/demo19/temperature.h
+++ b/demos/demo19/temperature.h
@@ -41,6 +41,13 @@ typedef struct _temperature_t {
    */
   double value;
 
+  /**
+   * @property {uint32_t} timer
+   * @annotation ["readable", "writable"]
+   * 计时（倒数）。
+   */
+  uint32_t timer;
+
   /*private*/
   double saved_value;
 } temperature_t;

--- a/demos/demo19/temperature_view_model.c
+++ b/demos/demo19/temperature_view_model.c
@@ -13,6 +13,10 @@ static ret_t temperature_view_model_set_prop(tk_object_t* obj, const char* name,
     atemperature->value = value_double(v);
 
     return RET_OK;
+  } else if (tk_str_ieq("timer", name)) {
+    atemperature->timer = value_uint32(v);
+
+    return RET_OK;
   }
   
   return RET_NOT_FOUND;
@@ -24,6 +28,9 @@ static ret_t temperature_view_model_get_prop(tk_object_t* obj, const char* name,
 
   if (tk_str_ieq("value", name)) {
     value_set_double(v, atemperature->value);
+    return RET_OK;
+  } else if (tk_str_ieq("timer", name)) {
+    value_set_uint32(v, atemperature->timer);
     return RET_OK;
   }
 


### PR DESCRIPTION
问题：demo19启动后定时器只运行一次
原因：int32_t time = tk_object_get_prop_int(view_model, PROP_TIME, 0) - 1;中属性获取失败，未定义timer属性
解决：直接从demo10的相关文件复制内容进来的。